### PR TITLE
Update Game.unity

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -2404,13 +2404,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: af82a886f7a9de04a9b98496b00c57ce, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  segment:
+  segmentTemplates:
   - {fileID: 1955829563}
   - {fileID: 1058255490}
   - {fileID: 373715091}
-  zPos: 50
-  creatingSegment: 0
-  segmentNum: 0
+  player: {fileID: 1422450348}
+  spawnDistanceAhead: 500
+  deleteDistanceBehind: 60
+  segmentLength: 50
 --- !u!4 &1606935005
 Transform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
fixes issue with segment generation by dragging the three segments to the LevelControls segment attachment. Player object is also correctly attached to the player section in LevelControls